### PR TITLE
Replace os.log with swift-log

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,9 +14,15 @@ let package = Package(
             name: "TibberSwift",
             targets: ["TibberSwift"]),
     ],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.6.1"),
+    ],
     targets: [
         .target(
             name: "TibberSwift",
+            dependencies: [
+                .product(name: "Logging", package: "swift-log"),
+            ],
             resources: [
                 .process("Queries")
             ]),


### PR DESCRIPTION
Hey @ppeelen,

thank you for your work on this project!

I tried to use it in an executable within a swift package, but unfortunately, it crashed.
`Bundle.main.bundleIdentifier` is an optional value, because there is no bundle identifier in non-bundled applications.

The crash occurred because of the forced unwrap of `bundleIdentifier` in the initializer of the logger. First I thought about making the value for the parameter `subsystem` accessible from outside, but I think it would be nicer to have https://github.com/apple/swift-log as a logging system.

This approach would allow users of this package to decide where to log, by using log handlers (which can still be os.log).

What do you think about this approach? Would you be open to considering a transition to SwiftLog for flexibility in logging?